### PR TITLE
fix activeTimeWindow functionality

### DIFF
--- a/fw/include/LedCtrl.h
+++ b/fw/include/LedCtrl.h
@@ -113,8 +113,8 @@ class LedCtrl {
   }
 
   void clear(void) {
-      Serial.println("Led clear");
       clearClockLeds();
+      FastLED.show();
   }
 
   void showNoWlan(void) {

--- a/fw/src/main.cpp
+++ b/fw/src/main.cpp
@@ -323,8 +323,15 @@ void loop() {
         ledCtrl.setLuma(luma);
       }
 
-      if (withinActiveTimeWindow(h, m)) ledCtrl.setClock(h, m);
-      else ledCtrl.clear();
+      static bool wasWithinActTimeWindow = false;
+      bool isWithinActTimeWindow = withinActiveTimeWindow(h, m);
+      if (isWithinActTimeWindow) 
+        ledCtrl.setClock(h, m);
+      else if (wasWithinActTimeWindow) {
+        Serial.println("now out of active time window, turning LEDs off");
+        ledCtrl.clear();
+      }
+      wasWithinActTimeWindow = isWithinActTimeWindow;
 
       //delay(250);
     } else {


### PR DESCRIPTION
Log output (blank lines added for readability):

```
nightOff active: 1
nightOff offH: 22
nightOff offM: 8
nightOff onH: 22
nightOff onM: 10
dim active: 0
dim base: 0
dim scale: 12
Committing EEPROM
Commit OK

newClock: 22:7
words to set: 6 26 24 20 25

now out of active time window, turning LEDs off

newClock: 22:10
words to set: 9 26 24 20 25
```

Changing the configuration on the fly is not a problem, because the time is evaluated on each loop.