### PR TITLE
allow using the configuration button during connection attempt

### DIFF
--- a/fw/src/main.cpp
+++ b/fw/src/main.cpp
@@ -259,6 +259,12 @@ void setupForNormal(void) {
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);
     Serial.print(".");
+    if(factoryReset) {
+      factoryReset = false;
+      ledCtrl.clear();
+      persistent.factoryReset();
+      ESP.restart();
+    }
   }
   ledCtrl.showWlan();
   delay(1000);  // indicate the connection before switching to the time
@@ -444,6 +450,9 @@ void setup() {
     Serial.begin(115200);
     persistent.setup();
 
+    pinMode(14, INPUT_PULLUP);
+    attachInterrupt(digitalPinToInterrupt(14), cfgBtnPressed, FALLING);
+
     if (!strcmp(persistent.ssid().c_str(), "")) {
       setupForInitialConfig();
     } else {
@@ -452,9 +461,6 @@ void setup() {
 
     server.onNotFound(notFound);
     server.begin();
-
-    pinMode(14, INPUT_PULLUP);
-    attachInterrupt(digitalPinToInterrupt(14), cfgBtnPressed, FALLING);
 
     Serial.println("Setup done");
 }


### PR DESCRIPTION
First of all: great project and good discription to preproduce it. Thanks for that.

I had problems in case of stored but invalid wifi connection settings.
This could be the case when
* moving the clock to another location with different wifi
* changing the wifi SSID or password
* enter wrong connection settings on first initialization

In my case using the config button doesn't have any effect while trying to connect to wifi with invalid settings.
So this change request checks the config button while wifi connection setup.